### PR TITLE
feat: Add Android file provider paths and bump version

### DIFF
--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+    <external-cache-path name="external_cache" path="."/>
+    <cache-path name="cache" path="."/>
+    <files-path name="files" path="."/>
+</paths>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A new Flutter project."
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 1.0.6
+version: 1.0.7
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
This commit introduces file provider paths for Android to enable secure file sharing and bumps the app version.

- **File Provider Paths:**
  - Adds `file_paths.xml` to define accessible directories (`external-path`, `external-cache-path`, `cache-path`, `files-path`) for the Android FileProvider.

- **Version Bump:**
  - Increments the application version from 1.0.6 to 1.0.7 in `pubspec.yaml`.