### PR TITLE
fix: Set modal background color

### DIFF
--- a/lib/screen/hymn/hymn_detail_screen.dart
+++ b/lib/screen/hymn/hymn_detail_screen.dart
@@ -641,6 +641,7 @@ class _HymnDetailScreenState extends State<HymnDetailScreen> {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setModalState) {
             return Container(
+              color: colorController.backgroundColor.value,
               padding: EdgeInsets.only(
                 bottom: MediaQuery.of(context).viewInsets.bottom,
                 left: 16,


### PR DESCRIPTION
Sets the background color of the hymn detail screen's modal container to match the theme's background color.