### PR TITLE
feat: Build universal APK for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
       # ----------------------
       - name: Build APKs
         working-directory: .
-        run: flutter build apk --release --split-per-abi
+        run: flutter build apk --release
 
       # ----------------------
       # Create GitHub Release


### PR DESCRIPTION
Removes the `--split-per-abi` flag from the `flutter build apk` command in the release workflow. This changes the build process to generate a single, universal APK containing binaries for all target ABIs instead of multiple, architecture-specific APKs.