### PR TITLE
refactor: Optimize hymn loading and favorite screen performance

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -30,8 +30,21 @@ jobs:
       - name: Generate App Icons
         run: flutter pub run flutter_launcher_icons:main
 
+      # ----------------------
+      # Verify assets are included
+      # ----------------------
+      - name: Verify assets
+        run: |
+          echo "Checking assets directory..."
+          ls -la assets/json/ | head -10
+          echo "Total JSON files: $(ls assets/json/*.json | wc -l)"
+          flutter pub get
+
+      # ----------------------
+      # Build with verbose output for debugging
+      # ----------------------
       - name: Build APK
-        run: flutter build apk --release
+        run: flutter build apk --release --verbose
 
       # Create GitHub Release
       - name: Create Release

--- a/lib/screen/favorite/favorites_screen.dart
+++ b/lib/screen/favorite/favorites_screen.dart
@@ -21,6 +21,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
   final ColorController colorController = Get.find<ColorController>();
   final AudioService _audioService = AudioService.instance;
   final Map<String, bool> _audioAvailability = {};
+  final Set<String> _checkedAudioHymns = <String>{};
 
   void _showAudioPlayerDialog(Hymn hymn) {
     showDialog(
@@ -70,11 +71,14 @@ class _FavoritesPageState extends State<FavoritesPage> {
   }
 
   Future<void> _checkAudioAvailability(String hymnId) async {
-    if (!_audioAvailability.containsKey(hymnId)) {
+    if (!_checkedAudioHymns.contains(hymnId)) {
+      _checkedAudioHymns.add(hymnId);
       final hasAudio = await _audioService.checkAudioFileExists(hymnId);
-      setState(() {
-        _audioAvailability[hymnId] = hasAudio;
-      });
+      if (mounted) {
+        setState(() {
+          _audioAvailability[hymnId] = hasAudio;
+        });
+      }
     }
   }
 
@@ -105,7 +109,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
       body: StreamBuilder<List<Hymn>>(
         stream: _hymnService.getFavoriteHymnsStream(),
         builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
+          if (snapshot.connectionState == ConnectionState.waiting && !snapshot.hasData) {
             return Center(
               child: CircularProgressIndicator(
                 valueColor: AlwaysStoppedAnimation<Color>(
@@ -136,9 +140,11 @@ class _FavoritesPageState extends State<FavoritesPage> {
                 final hymn = favoriteHymns[index];
                 
                 // Check audio availability when item is built
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  _checkAudioAvailability(hymn.id);
-                });
+                if (!_checkedAudioHymns.contains(hymn.id)) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    _checkAudioAvailability(hymn.id);
+                  });
+                }
                 
                 return Padding(
                   padding: const EdgeInsets.only(bottom: 12.0),

--- a/lib/services/hymn_service.dart
+++ b/lib/services/hymn_service.dart
@@ -218,19 +218,29 @@ class HymnService {
   }
 
   Stream<List<Hymn>> getFavoriteHymnsStream() {
-    return getFavoriteStatusStream().asyncMap((favoriteStatus) async {
-      if (favoriteStatus.isEmpty) return [];
+    return getFavoriteStatusStream().transform(
+      StreamTransformer.fromHandlers(
+        handleData: (favoriteStatus, sink) async {
+          if (favoriteStatus.isEmpty) {
+            sink.add([]);
+            return;
+          }
 
-      final List<Hymn> favoriteHymns = [];
-      for (final hymnId in favoriteStatus.keys) {
-        final hymn = await getHymnById(hymnId);
-        if (hymn != null) {
-          favoriteHymns.add(hymn);
-        }
-      }
-
-      return favoriteHymns;
-    });
+          try {
+            final List<Hymn> favoriteHymns = [];
+            for (final hymnId in favoriteStatus.keys) {
+              final hymn = await getHymnById(hymnId);
+              if (hymn != null) {
+                favoriteHymns.add(hymn);
+              }
+            }
+            sink.add(favoriteHymns);
+          } catch (e) {
+            sink.addError(e);
+          }
+        },
+      ),
+    );
   }
 
   Future<void> toggleFavorite(Hymn hymn) async {

--- a/lib/services/local_hymn_service.dart
+++ b/lib/services/local_hymn_service.dart
@@ -17,7 +17,7 @@ class LocalHymnService {
     }
 
     try {
-      // Try to load from manifest first (debug mode)
+      // Try to load from manifest first
       try {
         final manifestContent =
             await rootBundle.loadString('AssetManifest.json');
@@ -29,6 +29,22 @@ class LocalHymnService {
             .where((key) =>
                 key.startsWith('assets/json/') && key.endsWith('.json'))
             .toList();
+
+        if (kDebugMode) {
+          print('Found ${jsonAssets.length} JSON assets in manifest');
+          if (jsonAssets.isNotEmpty) {
+            print('First few assets: ${jsonAssets.take(5).join(', ')}');
+          }
+        }
+
+        if (jsonAssets.isEmpty) {
+          if (kDebugMode) {
+            print('No JSON assets found in manifest, trying fallback method');
+            print('Total manifest keys: ${manifestMap.keys.length}');
+            print('Sample manifest keys: ${manifestMap.keys.take(10).toList()}');
+          }
+          return await _loadHymnsFallback();
+        }
 
         // Process assets in smaller batches to avoid memory issues
         const batchSize = 20;
@@ -69,8 +85,8 @@ class LocalHymnService {
       } catch (manifestError) {
         // If manifest loading fails, try fallback method for release mode
         if (kDebugMode) {
-          print(
-              'AssetManifest loading failed, trying fallback method: $manifestError');
+            print(
+                'AssetManifest loading failed, trying fallback method: $manifestError');
         }
         return await _loadHymnsFallback();
       }
@@ -86,26 +102,51 @@ class LocalHymnService {
   Future<List<Hymn>> _loadHymnsFallback() async {
     final List<Hymn> hymns = [];
 
-    // Try to load a few sample hymns to check if the system works
     try {
-      // This is a fallback approach - in a real app, you might want to
-      // have a predefined list of hymn IDs or use a different approach
+      // Try a range of hymn IDs based on the actual file count
+      // We know there are 829 JSON files from our check
       for (int i = 1; i <= 1000; i++) {
         try {
-          final assetPath = 'assets/json/$i.json';
-          final jsonString = await rootBundle.loadString(assetPath);
-          final jsonData = json.decode(jsonString);
+          // Try different naming patterns
+          final possiblePaths = [
+            'assets/json/$i.json',
+            'assets/json/${i.toString().padLeft(3, '0')}.json',
+          ];
 
-          final hymn = _parseHymnFromJson(jsonData, i.toString());
-          hymns.add(hymn);
-          _hymnCache[hymn.id] = hymn;
+          Hymn? hymn;
+          for (final path in possiblePaths) {
+            try {
+              final jsonString = await rootBundle.loadString(path);
+              final jsonData = json.decode(jsonString);
+              hymn = _parseHymnFromJson(jsonData, i.toString());
+              break;
+            } catch (pathError) {
+              continue;
+            }
+          }
+
+          if (hymn != null) {
+            hymns.add(hymn);
+            _hymnCache[hymn.id] = hymn;
+          }
         } catch (e) {
           // Continue with next hymn
           continue;
         }
+
+        // Add a small delay every 50 hymns to prevent overwhelming the system
+        if (i % 50 == 0) {
+          await Future.delayed(const Duration(milliseconds: 5));
+        }
       }
 
       if (hymns.isNotEmpty) {
+        if (kDebugMode) {
+          print('Loaded ${hymns.length} hymns using fallback method');
+          print('First hymn: ${hymns.first.title} (${hymns.first.hymnNumber})');
+          print('Last hymn: ${hymns.last.title} (${hymns.last.hymnNumber})');
+        }
+        
         hymns.sort((a, b) {
           final numA = int.tryParse(a.hymnNumber) ?? 0;
           final numB = int.tryParse(b.hymnNumber) ?? 0;


### PR DESCRIPTION
This commit introduces several optimizations and fixes:

- Implements a more robust hymn loading mechanism in `LocalHymnService`. It now includes a fallback method that iterates through potential hymn file IDs if loading from the `AssetManifest.json` fails or returns no assets. This improves resilience, especially in release builds.
- Adds debug logging to the hymn loading process for better diagnostics.
- Optimizes the `FavoritesScreen` by preventing redundant audio availability checks. A `Set` is now used to track which hymns have already been checked, reducing unnecessary `AudioService` calls.
- Refactors the favorite hymns stream in `HymnService` to use a `StreamTransformer`, improving its structure.
- Enhances the CI workflow in `dart.yml` by adding steps to verify asset inclusion and enabling verbose output for the APK build to aid in debugging build issues.