### PR TITLE
chore: Pin Flutter version to 3.35.7 in GitHub workflows

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.35.7'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.35.7'
           cache: true
 
       # ----------------------


### PR DESCRIPTION
This commit updates the GitHub Actions workflows (`release.yml` and `dart.yml`) to use a specific Flutter version, `3.35.7`, instead of tracking the `stable` channel. This ensures that CI builds use a consistent and predictable version of the Flutter SDK.