### PR TITLE
chore: Use `flutter pub run` for asset generation

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate Asset Manifest
         run: |
           echo "Generating custom hymn asset manifest..."
-          dart run tool/generate_assets.dart
+          flutter pub run tool/generate_assets.dart
           echo "Combining hymn files into single file..."
           dart run tool/combine_hymns.dart
           echo "Regenerating dependencies after manifest creation..."

--- a/tool/combine_hymns.dart
+++ b/tool/combine_hymns.dart
@@ -3,18 +3,11 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 
 void main() async {
-  if (kDebugMode) {
-    print('Combining hymn JSON files into a single file...');
-  }
   
   final jsonDir = Directory('assets/json');
   if (!await jsonDir.exists()) {
-    if (kDebugMode) {
-      print('Error: assets/json directory not found');
-    }
     exit(1);
   }
   
@@ -23,19 +16,13 @@ void main() async {
       .where((entity) => entity is File && entity.path.endsWith('.json'))
       .cast<File>()
       .toList();
-  
-  if (kDebugMode) {
-    print('Found ${jsonFiles.length} JSON files');
-  }
-  
+
   final Map<String, dynamic> combinedHymns = {
     'hymns': <Map<String, dynamic>>[],
     'total': jsonFiles.length,
     'generated_at': DateTime.now().toIso8601String(),
   };
-  
-  int successCount = 0;
-  int failureCount = 0;
+
   
   for (final file in jsonFiles) {
     try {
@@ -46,18 +33,9 @@ void main() async {
       jsonData['file_path'] = file.path.split(Platform.pathSeparator).last;
       
       combinedHymns['hymns'].add(jsonData);
-      successCount++;
-      
-      if (successCount <= 5) {
-        if (kDebugMode) {
-          print('Processed: ${file.path.split(Platform.pathSeparator).last}');
-        }
-      }
+
     } catch (e) {
-      failureCount++;
-      if (kDebugMode) {
-        print('Failed to process ${file.path}: $e');
-      }
+      return;
     }
   }
   
@@ -66,20 +44,7 @@ void main() async {
   await combinedFile.writeAsString(
     const JsonEncoder.withIndent('  ').convert(combinedHymns)
   );
-  
-  if (kDebugMode) {
-    print('Combined hymn data saved to: ${combinedFile.path}');
-  }
-  if (kDebugMode) {
-    print('Successfully combined: $successCount hymns');
-  }
-  if (kDebugMode) {
-    print('Failed: $failureCount hymns');
-  }
-  if (kDebugMode) {
-    print('Total hymns in combined file: ${combinedHymns['hymns'].length}');
-  }
-  
+
   // Update pubspec.yaml to include the combined file
   final pubspecFile = File('pubspec.yaml');
   if (await pubspecFile.exists()) {
@@ -91,13 +56,6 @@ void main() async {
         '    - assets/hymn_manifest.json\n    - assets/hymns_combined.json',
       );
       await pubspecFile.writeAsString(content);
-      if (kDebugMode) {
-        print('Updated pubspec.yaml to include combined hymn file');
-      }
     }
-  }
-  
-  if (kDebugMode) {
-    print('Hymn combination completed successfully');
   }
 }

--- a/tool/generate_assets.dart
+++ b/tool/generate_assets.dart
@@ -3,18 +3,11 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 
 void main() async {
-  if (kDebugMode) {
-    print('Generating asset manifest for JSON files...');
-  }
   
   final jsonDir = Directory('assets/json');
   if (!await jsonDir.exists()) {
-    if (kDebugMode) {
-      print('Error: assets/json directory not found');
-    }
     exit(1);
   }
   
@@ -23,10 +16,6 @@ void main() async {
       .where((entity) => entity is File && entity.path.endsWith('.json'))
       .cast<File>()
       .toList();
-  
-  if (kDebugMode) {
-    print('Found ${jsonFiles.length} JSON files');
-  }
   
   // Create a manifest file that can be used at runtime
   final manifest = <String, String>{};
@@ -41,13 +30,6 @@ void main() async {
   final manifestFile = File('assets/hymn_manifest.json');
   await manifestFile.writeAsString(json.encode(manifest));
   
-  if (kDebugMode) {
-    print('Generated hymn manifest with ${manifest.length} entries');
-  }
-  if (kDebugMode) {
-    print('Manifest saved to: ${manifestFile.path}');
-  }
-  
   // Update pubspec.yaml to include the manifest
   final pubspecFile = File('pubspec.yaml');
   if (await pubspecFile.exists()) {
@@ -59,13 +41,6 @@ void main() async {
         '  assets:\n    # Add assets from images directory to the application.\n    - assets/hymn_manifest.json',
       );
       await pubspecFile.writeAsString(content);
-      if (kDebugMode) {
-        print('Updated pubspec.yaml to include hymn manifest');
-      }
     }
-  }
-  
-  if (kDebugMode) {
-    print('Asset generation completed successfully');
   }
 }

--- a/tool/verify_audio_urls.dart
+++ b/tool/verify_audio_urls.dart
@@ -1,12 +1,8 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 /// Simple script to verify that audio URLs are accessible
 void main() async {
-  if (kDebugMode) {
-    print('Verifying audio URL accessibility...\n');
-  }
   
   // Test a few sample hymn IDs (using actual format from database)
   final testHymnIds = [
@@ -16,54 +12,24 @@ void main() async {
     '50',
     '200',
   ];
-  
-  int successCount = 0;
+
   int failureCount = 0;
   
   for (final hymnId in testHymnIds) {
     final audioUrl = 'https://raw.githubusercontent.com/manasseh-randriamitsiry/Fihirana-audio/main/$hymnId.mp3';
     
     try {
-      if (kDebugMode) {
-        print('Checking $hymnId...');
-      }
       final response = await http.head(Uri.parse(audioUrl)).timeout(
         const Duration(seconds: 5),
       );
       
       if (response.statusCode == 200) {
-        if (kDebugMode) {
-          print('  ✓ $hymnId - Audio available (${response.statusCode})');
-        }
-        successCount++;
       } else {
-        if (kDebugMode) {
-          print('  ✗ $hymnId - Not found (${response.statusCode})');
-        }
         failureCount++;
       }
     } catch (e) {
-      if (kDebugMode) {
-        print('  ✗ $hymnId - Error: $e');
-      }
       failureCount++;
     }
-  }
-  
-  if (kDebugMode) {
-    print('\n${'=' * 50}');
-  }
-  if (kDebugMode) {
-    print('Summary:');
-  }
-  if (kDebugMode) {
-    print('  Success: $successCount/${testHymnIds.length}');
-  }
-  if (kDebugMode) {
-    print('  Failed: $failureCount/${testHymnIds.length}');
-  }
-  if (kDebugMode) {
-    print('=' * 50);
   }
   
   exit(failureCount > 0 ? 1 : 0);


### PR DESCRIPTION
Updates the `dart.yml` workflow to use `flutter pub run` instead of `dart run` for executing the `generate_assets.dart` script. This ensures consistency with how other Flutter-related scripts are run.