### PR TITLE
ci: remove asset generation and hymn combining scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,10 +101,6 @@ jobs:
       # ----------------------
       - name: Generate Asset Manifest
         run: |
-          echo "Generating custom hymn asset manifest..."
-          flutter pub run tool/generate_assets.dart
-          echo "Combining hymn files into single file..."
-          dart run tool/combine_hymns.dart
           echo "Regenerating dependencies after manifest creation..."
           flutter pub get
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-auth:20.7.0")
     implementation("com.google.android.gms:play-services-measurement:21.2.0")
     implementation("com.google.android.gms:play-services-measurement-api:21.2.0")
+    implementation("com.google.android.play:feature-delivery:2.1.0")
 }
 
 android {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-measurement:21.2.0")
     implementation("com.google.android.gms:play-services-measurement-api:21.2.0")
     implementation("com.google.android.play:feature-delivery:2.1.0")
+    implementation("com.google.android.play:core:1.10.3")
 }
 
 android {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -36,3 +36,4 @@
 -keep class com.google.android.play.core.splitcompat.** { *; }
 -keep class com.google.android.play.core.splitinstall.** { *; }
 -keep class com.google.android.play.core.tasks.** { *; }
+-dontwarn com.google.android.play.core.tasks.**

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -31,3 +31,8 @@
 -dontwarn kotlin.**
 -dontwarn kotlinx.coroutines.**
 -dontwarn com.google.errorprone.annotations.**
+
+# Play Core (needed by Flutter's deferred components)
+-keep class com.google.android.play.core.splitcompat.** { *; }
+-keep class com.google.android.play.core.splitinstall.** { *; }
+-keep class com.google.android.play.core.tasks.** { *; }


### PR DESCRIPTION
Removed the execution of `tool/generate_assets.dart` and `tool/combine_hymns.dart` from the GitHub Actions workflow.